### PR TITLE
为虚拟机生命周期管理添加二次确认对话框，优化空状态提示

### DIFF
--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -4204,5 +4204,68 @@ namespace ExHyperV.Properties {
                 return ResourceManager.GetString("Weight", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   查找类似 Confirm Restart 的本地化字符串。
+        /// </summary>
+        public static string Confirm_Restart_Title {
+            get {
+                return ResourceManager.GetString("Confirm_Restart_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Are you sure you want to restart the virtual machine? 的本地化字符串。
+        /// </summary>
+        public static string Confirm_Restart_Message {
+            get {
+                return ResourceManager.GetString("Confirm_Restart_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Confirm Shutdown 的本地化字符串。
+        /// </summary>
+        public static string Confirm_Shutdown_Title {
+            get {
+                return ResourceManager.GetString("Confirm_Shutdown_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Are you sure you want to shut down the virtual machine? 的本地化字符串。
+        /// </summary>
+        public static string Confirm_Shutdown_Message {
+            get {
+                return ResourceManager.GetString("Confirm_Shutdown_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Confirm Force Power Off 的本地化字符串。
+        /// </summary>
+        public static string Confirm_TurnOff_Title {
+            get {
+                return ResourceManager.GetString("Confirm_TurnOff_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Are you sure you want to force power off the virtual machine? 的本地化字符串。
+        /// </summary>
+        public static string Confirm_TurnOff_Message {
+            get {
+                return ResourceManager.GetString("Confirm_TurnOff_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Please select a virtual machine 的本地化字符串。
+        /// </summary>
+        public static string Instances_SelectVmPrompt {
+            get {
+                return ResourceManager.GetString("Instances_SelectVmPrompt", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -1514,4 +1514,31 @@ Please check if the IP and port are correct.</value>
   <data name="Status_Title_SwitchEdition" xml:space="preserve">
     <value>Switch System Edition</value>
   </data>
+  <data name="Confirm_Restart_Title" xml:space="preserve">
+    <value>Confirm Restart</value>
+  </data>
+  <data name="Confirm_Restart_Message" xml:space="preserve">
+    <value>Are you sure you want to restart the virtual machine "{0}"?
+
+This will interrupt all running services and programs.</value>
+  </data>
+  <data name="Confirm_Shutdown_Title" xml:space="preserve">
+    <value>Confirm Shutdown</value>
+  </data>
+  <data name="Confirm_Shutdown_Message" xml:space="preserve">
+    <value>Are you sure you want to shut down the virtual machine "{0}"?
+
+This operation sends a shutdown signal to the guest OS.</value>
+  </data>
+  <data name="Confirm_TurnOff_Title" xml:space="preserve">
+    <value>Confirm Force Power Off</value>
+  </data>
+  <data name="Confirm_TurnOff_Message" xml:space="preserve">
+    <value>Are you sure you want to force power off the virtual machine "{0}"?
+
+⚠️ Warning: This is equivalent to unplugging the power cord and may cause data loss or file system corruption!</value>
+  </data>
+  <data name="Instances_SelectVmPrompt" xml:space="preserve">
+    <value>Please select a virtual machine</value>
+  </data>
 </root>

--- a/src/Properties/Resources.zh-CN.resx
+++ b/src/Properties/Resources.zh-CN.resx
@@ -1515,4 +1515,31 @@
   <data name="Status_Title_SwitchEdition" xml:space="preserve">
     <value>切换系统版本</value>
   </data>
+  <data name="Confirm_Restart_Title" xml:space="preserve">
+    <value>确认重启</value>
+  </data>
+  <data name="Confirm_Restart_Message" xml:space="preserve">
+    <value>确定要重启虚拟机 "{0}" 吗？
+
+这将中断所有正在运行的服务和程序。</value>
+  </data>
+  <data name="Confirm_Shutdown_Title" xml:space="preserve">
+    <value>确认关机</value>
+  </data>
+  <data name="Confirm_Shutdown_Message" xml:space="preserve">
+    <value>确定要关闭虚拟机 "{0}" 吗？
+
+此操作将向客户机操作系统发送关机信号。</value>
+  </data>
+  <data name="Confirm_TurnOff_Title" xml:space="preserve">
+    <value>确认强制断电</value>
+  </data>
+  <data name="Confirm_TurnOff_Message" xml:space="preserve">
+    <value>确定要强制断电虚拟机 "{0}" 吗？
+
+⚠️ 警告：此操作相当于直接拔掉电源线，可能导致数据丢失或文件系统损坏！</value>
+  </data>
+  <data name="Instances_SelectVmPrompt" xml:space="preserve">
+    <value>请选择虚拟机</value>
+  </data>
 </root>

--- a/src/Tools/DialogManager.cs
+++ b/src/Tools/DialogManager.cs
@@ -8,6 +8,64 @@ namespace ExHyperV.Tools
 {
     public static class DialogManager
     {
+        /// <summary>
+        /// 显示确认对话框，返回用户是否确认
+        /// </summary>
+        public static async Task<bool> ShowConfirmAsync(string title, string message, string confirmButtonText = null, string cancelButtonText = null, bool isDanger = false)
+        {
+            if (Application.Current.MainWindow is not MainWindow mainWindow)
+            {
+                return false;
+            }
+
+            var dialogHost = mainWindow.ContentPresenterForDialogs;
+            if (dialogHost == null)
+            {
+                return false;
+            }
+
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(40) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            var icon = new FontIcon
+            {
+                FontFamily = Application.Current.FindResource("SegoeFluentIcons") as FontFamily,
+                Glyph = isDanger ? "\uE7BA" : "\uE946", // Warning icon for danger, Info icon otherwise
+                FontSize = 28,
+                VerticalAlignment = VerticalAlignment.Center,
+                Foreground = isDanger ? new SolidColorBrush(System.Windows.Media.Color.FromRgb(196, 43, 28)) : null
+            };
+
+            var contentTextBlock = new TextBlock
+            {
+                Text = message,
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 14,
+                LineHeight = 24,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(12, 0, 0, 0)
+            };
+
+            Grid.SetColumn(icon, 0);
+            Grid.SetColumn(contentTextBlock, 1);
+            grid.Children.Add(icon);
+            grid.Children.Add(contentTextBlock);
+
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                Content = grid,
+                PrimaryButtonText = confirmButtonText ?? Properties.Resources.sure,
+                CloseButtonText = cancelButtonText ?? Properties.Resources.cancel,
+                DialogHost = dialogHost,
+                PrimaryButtonAppearance = isDanger ? ControlAppearance.Danger : ControlAppearance.Primary
+            };
+
+            var result = await dialog.ShowAsync(CancellationToken.None);
+            return result == ContentDialogResult.Primary;
+        }
+
         public static async Task ShowAlertAsync(string title, string message)
         {
             if (Application.Current.Dispatcher.CheckAccess())

--- a/src/Views/InstancesPage.xaml
+++ b/src/Views/InstancesPage.xaml
@@ -17,12 +17,22 @@
         <converters:VmNameToIconConverter x:Key="VmNameToIconConverter" />
         <converters:OsTypeToImageConverter x:Key="OsTypeToImageConverter" />
 
-        <!-- 修复：补回加载中模板 -->
+        <!-- 加载中模板 -->
         <DataTemplate x:Key="VmLoadingTemplate">
             <Border Background="{ui:ThemeResource ControlFillColorDefaultBrush}" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="4">
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
                     <ui:ProgressRing IsIndeterminate="True" Margin="0,0,0,10"/>
                     <TextBlock Text="{x:Static properties:Resources.DataLoading}" Opacity="0.5" />
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+        
+        <!-- 请选择虚拟机提示模板 -->
+        <DataTemplate x:Key="VmSelectPromptTemplate">
+            <Border Background="{ui:ThemeResource ControlFillColorDefaultBrush}" BorderBrush="{ui:ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="4">
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <ui:SymbolIcon Symbol="Desktop24" FontSize="48" Margin="0,0,0,12" Opacity="0.4"/>
+                    <TextBlock Text="{x:Static properties:Resources.Instances_SelectVmPrompt}" Opacity="0.5" FontSize="14"/>
                 </StackPanel>
             </Border>
         </DataTemplate>
@@ -217,9 +227,18 @@
                     <Style TargetType="ContentControl">
                         <Setter Property="ContentTemplate" Value="{StaticResource VmDetailTemplate}"/>
                         <Style.Triggers>
-                            <Trigger Property="Content" Value="{x:Null}">
+                            <!-- 正在加载时显示加载中模板 -->
+                            <DataTrigger Binding="{Binding IsLoading}" Value="True">
                                 <Setter Property="ContentTemplate" Value="{StaticResource VmLoadingTemplate}"/>
-                            </Trigger>
+                            </DataTrigger>
+                            <!-- 未选择虚拟机且未在加载时显示提示模板 -->
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding SelectedVm}" Value="{x:Null}"/>
+                                    <Condition Binding="{Binding IsLoading}" Value="False"/>
+                                </MultiDataTrigger.Conditions>
+                                <Setter Property="ContentTemplate" Value="{StaticResource VmSelectPromptTemplate}"/>
+                            </MultiDataTrigger>
                         </Style.Triggers>
                     </Style>
                 </ContentControl.Style>


### PR DESCRIPTION
新增功能
1. 危险操作二次确认 为虚拟机的重启、关机、强制断电操作添加了二次确认对话框
启动、暂停、保存等安全操作保持原有行为，无需确认
2. DialogManager 新增通用确认方法 添加 ShowConfirmAsync 方法，支持自定义标题、消息、按钮文本
支持 isDanger 参数，启用后显示红色警告样式
优化改进
3. 优化生命周期管理页面空状态提示 数据加载时显示"数据加载中..."（带进度环）
加载完成但未选择虚拟机时显示"请选择虚拟机"（带图标提示）
