### PR TITLE
改进 Linux 客户机的 GPU 活动检测

### DIFF
--- a/src/ViewModels/VmInstanceInfo.cs
+++ b/src/ViewModels/VmInstanceInfo.cs
@@ -534,7 +534,12 @@ namespace ExHyperV.Models
                 GpuEncodeUsage = Math.Clamp(data.GpuEncode, 0, 100);
                 GpuDecodeUsage = Math.Clamp(data.GpuDecode, 0, 100);
 
-                IsGpuActive = data.IsDriverBound;
+                bool hasEngineUsage = Gpu3dUsage > 0 || GpuCopyUsage > 0 || GpuEncodeUsage > 0 || GpuDecodeUsage > 0;
+                bool isLinuxGuest = !string.IsNullOrWhiteSpace(OsType) && OsType.Contains("linux", StringComparison.OrdinalIgnoreCase);
+
+                // For Linux guests, Windows "GPU Engine" counters can be missing even when GPU-P is working.
+                // Keep panel active to show detailed metrics instead of forcing "driver not ready".
+                IsGpuActive = data.IsDriverBound || hasEngineUsage || (HasGpu && isLinuxGuest);
             }
             UpdateSingleGpuHistory(_gpu3dHistory, Gpu3dUsage);
             UpdateSingleGpuHistory(_gpuCopyHistory, GpuCopyUsage);


### PR DESCRIPTION
在确定 IsGpuActive 时考虑 GPU 引擎使用情况和 Linux 客机。增加了对任何引擎使用（3D、拷贝、编码、解码）的检查，以及一个不区分大小写的 Linux 客机检测，并更新了 IsGpuActive，使其在驱动绑定、任何引擎显示使用，或虚拟机是带 GPU 的 Linux 客机时保持为 true。这可以防止在 Linux 客机的 Windows GPU 引擎计数器缺失时，界面将 GPU 标记为非活动，同时允许详细的 GPU 指标保持可见。
主要针对arch