### PR TITLE
修复 无法加载宿主机显卡

### DIFF
--- a/src/Services/VmGPUService.cs
+++ b/src/Services/VmGPUService.cs
@@ -127,10 +127,11 @@ namespace ExHyperV.Services
                 {
                     foreach (var gpu in gpulinked)
                     {
-                        string name = gpu.Members["name"]?.Value.ToString();
-                        string instanceId = gpu.Members["PNPDeviceID"]?.Value.ToString();
-                        string manu = gpu.Members["AdapterCompatibility"]?.Value.ToString();
-                        string driverVersion = gpu.Members["DriverVersion"]?.Value.ToString();
+                        string name = gpu.Members["name"]?.Value?.ToString();
+                        string instanceId = gpu.Members["PNPDeviceID"]?.Value?.ToString();
+                        string manu = gpu.Members["AdapterCompatibility"]?.Value?.ToString();
+                        string driverVersion = gpu.Members["DriverVersion"]?.Value?.ToString();
+                        if (name == null || instanceId == null || manu == null || driverVersion == null) continue;
                         string vendor = pciInfoProvider.GetVendorFromInstanceId(instanceId);
                         if (instanceId != null && !instanceId.ToUpper().StartsWith("PCI\\") && !instanceId.ToUpper().Contains("ACPI")) continue;
                         gpuList.Add(new GPUInfo(name, "True", manu, instanceId, null, null, driverVersion, vendor));


### PR DESCRIPTION
fix #130
修改了 硬件信息与虚拟机查询`GetHostGpusAsync()` 中的代码，使其能处理类似于`gpu.Members["name"]?.Value`为null的情况

修复后点击 添加 能够正常识别显卡：
<img width="1375" height="1000" alt="image" src="https://github.com/user-attachments/assets/eca149bb-8841-4141-a220-a1cdc8d163a4" />
<img width="1375" height="1000" alt="777287b6575fbd85c088cb2dfa946783" src="https://github.com/user-attachments/assets/322a9904-388f-41d8-8981-7ff56826ca13" />
<img width="1922" height="1206" alt="3b1be206d92294cd1f85f8a3338f494b" src="https://github.com/user-attachments/assets/d08b96aa-9378-46f8-88ae-c72286c6db1c" />
修改后成功为虚拟机添加显卡