### PR TITLE
自动化提交到 Winget 官方仓库

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,3 +71,12 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # 自动化提交到 Winget 官方仓库
+      - name: Submit to Winget
+        if: steps.check_tag.outputs.EXISTS == 'false'
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Justsenger.ExHyperV  # （需先手动提交一次初版）
+          installers-regex: '\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }} # 需要在仓库设置中配置 PAT


### PR DESCRIPTION
关联 Issue: #163 

目前项目的发布流程 仅包含 GitHub Releases。为了降低用户的安装与更新门槛，本 PR 为 publish.yml 增加了自动化分发逻辑，支持将新版本自动推送到 Winget 官方仓库。

在 .github/workflows/publish.yml 中新增了 Submit to Winget 步骤。