### PR TITLE
fix: 为所有文件/文件夹浏览对话框设置初始目录

### DIFF
--- a/src/ViewModels/VirtualMachinesPageViewModel.cs
+++ b/src/ViewModels/VirtualMachinesPageViewModel.cs
@@ -528,7 +528,11 @@ namespace ExHyperV.ViewModels
         [RelayCommand]
         private void BrowseNewVmPath()
         {
-            var dialog = new Microsoft.Win32.OpenFolderDialog { Title = Properties.Resources.VmPage_SelectConfigDir };
+            var dialog = new Microsoft.Win32.OpenFolderDialog
+            {
+                Title = Properties.Resources.VmPage_SelectConfigDir,
+                InitialDirectory = string.IsNullOrWhiteSpace(NewVmStoragePath) ? string.Empty : NewVmStoragePath
+            };
             if (dialog.ShowDialog() == true)
             {
                 NewVmStoragePath = dialog.FolderName;
@@ -543,7 +547,8 @@ namespace ExHyperV.ViewModels
             {
                 Title = Properties.Resources.VmPage_SelectNewVhdPath,
                 Filter = Properties.Resources.VmPage_VhdFilter,
-                FileName = $"{NewVmName}.vhdx"
+                InitialDirectory = string.IsNullOrWhiteSpace(NewVmNewDiskPath) ? string.Empty : System.IO.Path.GetDirectoryName(NewVmNewDiskPath),
+                FileName = string.IsNullOrWhiteSpace(NewVmNewDiskPath) ? $"{NewVmName}.vhdx" : System.IO.Path.GetFileName(NewVmNewDiskPath)
             };
             if (dialog.ShowDialog() == true) NewVmNewDiskPath = dialog.FileName;
         }
@@ -554,7 +559,8 @@ namespace ExHyperV.ViewModels
             var dialog = new Microsoft.Win32.OpenFileDialog
             {
                 Title = Properties.Resources.VmPage_SelectExistVhd,
-                Filter = Properties.Resources.VmPage_VhdFilterBoth
+                Filter = Properties.Resources.VmPage_VhdFilterBoth,
+                InitialDirectory = string.IsNullOrWhiteSpace(NewVmExistingDiskPath) ? string.Empty : System.IO.Path.GetDirectoryName(NewVmExistingDiskPath)
             };
             if (dialog.ShowDialog() == true) NewVmExistingDiskPath = dialog.FileName;
         }
@@ -565,7 +571,8 @@ namespace ExHyperV.ViewModels
             var dialog = new Microsoft.Win32.OpenFileDialog
             {
                 Title = Properties.Resources.VmPage_SelectIso,
-                Filter = Properties.Resources.VmPage_IsoFilter
+                Filter = Properties.Resources.VmPage_IsoFilter,
+                InitialDirectory = string.IsNullOrWhiteSpace(NewVmIsoPath) ? string.Empty : System.IO.Path.GetDirectoryName(NewVmIsoPath)
             };
             if (dialog.ShowDialog() == true) NewVmIsoPath = dialog.FileName;
         }
@@ -1906,7 +1913,8 @@ namespace ExHyperV.ViewModels
                     Title = Properties.Resources.Title_CreateVhd,
                     Filter = Properties.Resources.Filter_VhdExt,
                     DefaultExt = ".vhdx",
-                    FileName = Properties.Resources.Default_VhdName
+                    InitialDirectory = string.IsNullOrWhiteSpace(FilePath) ? string.Empty : System.IO.Path.GetDirectoryName(FilePath),
+                    FileName = string.IsNullOrWhiteSpace(FilePath) ? Properties.Resources.Default_VhdName : System.IO.Path.GetFileName(FilePath)
                 };
 
                 if (saveDialog.ShowDialog() == true)
@@ -1921,7 +1929,8 @@ namespace ExHyperV.ViewModels
                     Title = DeviceType == "HardDisk" ? Properties.Resources.Title_OpenVhd : Properties.Resources.Title_SelectIso,
                     Filter = DeviceType == "HardDisk" ?
                              Properties.Resources.Filter_VhdOnly :
-                             Properties.Resources.Filter_IsoOnly
+                             Properties.Resources.Filter_IsoOnly,
+                    InitialDirectory = string.IsNullOrWhiteSpace(FilePath) ? string.Empty : System.IO.Path.GetDirectoryName(FilePath)
                 };
 
                 if (openDialog.ShowDialog() == true)
@@ -1935,7 +1944,10 @@ namespace ExHyperV.ViewModels
         [RelayCommand]
         private void BrowseFolder()
         {
-            var dialog = new Microsoft.Win32.OpenFolderDialog();
+            var dialog = new Microsoft.Win32.OpenFolderDialog
+            {
+                InitialDirectory = string.IsNullOrWhiteSpace(IsoSourceFolderPath) ? string.Empty : IsoSourceFolderPath
+            };
             if (dialog.ShowDialog() == true) IsoSourceFolderPath = dialog.FolderName;
         }
 
@@ -1943,7 +1955,11 @@ namespace ExHyperV.ViewModels
         [RelayCommand]
         private void BrowseParentFile()
         {
-            var dialog = new Microsoft.Win32.OpenFileDialog { Filter = Properties.Resources.Filter_VhdOnly };
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Filter = Properties.Resources.Filter_VhdOnly,
+                InitialDirectory = string.IsNullOrWhiteSpace(ParentPath) ? string.Empty : System.IO.Path.GetDirectoryName(ParentPath)
+            };
             if (dialog.ShowDialog() == true) ParentPath = dialog.FileName;
         }
 
@@ -1956,7 +1972,8 @@ namespace ExHyperV.ViewModels
                 Title = Properties.Resources.Title_SaveIso,
                 Filter = Properties.Resources.Filter_IsoExt,
                 DefaultExt = ".iso",
-                FileName = $"{IsoVolumeLabel}.iso"
+                InitialDirectory = string.IsNullOrWhiteSpace(IsoOutputPath) ? string.Empty : System.IO.Path.GetDirectoryName(IsoOutputPath),
+                FileName = string.IsNullOrWhiteSpace(IsoOutputPath) ? $"{IsoVolumeLabel}.iso" : System.IO.Path.GetFileName(IsoOutputPath)
             };
 
             if (saveDialog.ShowDialog() == true)


### PR DESCRIPTION
Fixes #165 

  改动记录 (Changes):
  优化了 VirtualMachinesPageViewModel.cs 中所有涉及文件/文件夹选择的命令逻辑。
   - 在调用 OpenFileDialog、SaveFileDialog 和 OpenFolderDialog 之前，增加了对
     InitialDirectory 属性的赋值。
   - 使用 System.IO.Path.GetDirectoryName 提取当前路径的父目录作为初始位置。
   - 涉及的功能点包括：新建虚拟机配置路径、新建虚拟硬盘位置、选择现有硬盘、挂载
     ISO 镜像、ISO 制作源码目录等。

  测试验证 (Testing):
   - [x] 在 Windows 环境下通过 `dotnet run` 验证，对话框现在能正确识别并跳转到已有路径。
   - [x] 验证了路径为空或非法路径时的回退机制（不会崩溃）。