### PR TITLE
修复软件启动时Mica背景未正确应用的问题

### DIFF
--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -9,7 +9,9 @@
         mc:Ignorable="d"
         Title="ExHyperV" Height="800" Width="1100"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        WindowBackdropType="Mica"
+        ExtendsContentIntoTitleBar="True">
     <Grid>
         <!-- 布局规划 -->
         <Grid.RowDefinitions>

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -18,10 +18,6 @@ namespace ExHyperV
             }
             else { ApplicationThemeManager.Apply(ApplicationTheme.Light); }
 
-            Loaded += (sender, args) =>  //监听系统切换主题事件
-            {
-                SystemThemeWatcher.Watch(this, WindowBackdropType.Mica, true);
-            };
         }
 
         private void PagePreload(object sender, RoutedEventArgs e)


### PR DESCRIPTION
这个 Pull Request 修复了[#146](https://github.com/Justsenger/ExHyperV/issues/146) ，或许对[#171](https://github.com/Justsenger/ExHyperV/issues/171)也有缓解，更新了主窗口的外观设置，并将系统主题变更的监控逻辑从代码中移除。最重要的改进如下：

**窗口外观优化：**  
- 在 `src/MainWindow.xaml` 中，窗口现在应当能够正确应用“Mica”背景效果，并将内容延伸到标题栏中，从而呈现出更加现代的外观。(`[src/MainWindow.xamlL12-R14](diffhunk://#diff-b0059240fc7f4e0ce19f8ac733c919c152cf5dbbb7a9945c1a27b5fd07781564L12-R14)`)

**主题管理重组：**  
- 在 `src/MainWindow.xaml.cs` 中，用于监控系统主题变化并应用“Mica”背景效果的初始化代码已被从窗口的 `Loaded` 事件处理程序中移除。因为“Mica”背景效果已通过 `WindowBackdropType="Mica"` 在 XAML 中进行配置。(`[src/MainWindow.xaml.csL21-L24](diffhunk://#diff-94708f41adea601b0413cb27a89eb9814e2faa7a5b3816f639b6e1f6ae250458L21-L24)`)