### PR TITLE
feat: 添加跟随系统主题模式并支持自动切换

### DIFF
--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -1067,7 +1067,16 @@ namespace ExHyperV.Properties {
                 return ResourceManager.GetString("Theme_Dark", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Follow System 的本地化字符串。
+        /// </summary>
+        public static string Theme_System {
+            get {
+                return ResourceManager.GetString("Theme_System", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Loading data... 的本地化字符串。
         /// </summary>

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -207,6 +207,9 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>Dark</value>
   </data>
+  <data name="Theme_System" xml:space="preserve">
+    <value>Follow System</value>
+  </data>
   <data name="Lang_Title" xml:space="preserve">
     <value>Language</value>
   </data>

--- a/src/Properties/Resources.zh-CN.resx
+++ b/src/Properties/Resources.zh-CN.resx
@@ -207,6 +207,9 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>黑暗</value>
   </data>
+  <data name="Theme_System" xml:space="preserve">
+    <value>跟随系统</value>
+  </data>
   <data name="Lang_Title" xml:space="preserve">
     <value>语言</value>
   </data>

--- a/src/Services/Shared/SettingsService.cs
+++ b/src/Services/Shared/SettingsService.cs
@@ -136,14 +136,105 @@ namespace ExHyperV.Services
         // 获取当前主题
         public static string GetTheme()
         {
-            return ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Dark ? Properties.Resources.Theme_Dark : Properties.Resources.Theme_Light;
+            if (_isFollowingSystem)
+                return Properties.Resources.Theme_System;
+
+            return ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Dark
+                ? Properties.Resources.Theme_Dark
+                : Properties.Resources.Theme_Light;
+        }
+
+        // 从XML加载主题设置
+        public static string GetSavedThemeCode()
+        {
+            if (!File.Exists(ConfigFilePath)) return "system";
+
+            try
+            {
+                XDocument configDoc = XDocument.Load(ConfigFilePath);
+                return configDoc.Root?.Element("Theme")?.Value ?? "system";
+            }
+            catch
+            {
+                return "system";
+            }
+        }
+
+        // 保存主题设置
+        private static void SaveThemeCode(string themeCode)
+        {
+            XDocument configDoc;
+            if (File.Exists(ConfigFilePath))
+            {
+                configDoc = XDocument.Load(ConfigFilePath);
+                var themeElement = configDoc.Root?.Element("Theme");
+                if (themeElement != null)
+                {
+                    themeElement.Value = themeCode;
+                }
+                else
+                {
+                    configDoc.Root?.Add(new XElement("Theme", themeCode));
+                }
+            }
+            else
+            {
+                configDoc = new XDocument(new XElement("Config", new XElement("Theme", themeCode)));
+            }
+            configDoc.Save(ConfigFilePath);
+        }
+
+        // 是否正在跟随系统主题
+        private static bool _isFollowingSystem = true;
+
+        // 根据保存的主题设置初始化主题
+        public static void ApplySavedTheme(Window? window = null)
+        {
+            var themeName = GetSavedThemeCode() switch
+            {
+                "dark" => Properties.Resources.Theme_Dark,
+                "light" => Properties.Resources.Theme_Light,
+                _ => Properties.Resources.Theme_System,
+            };
+
+            ApplyTheme(themeName, window, saveTheme: false);
         }
 
         // 应用新主题
-        public static void ApplyTheme(string themeName)
+        public static void ApplyTheme(string themeName, Window? window = null, bool saveTheme = true)
         {
-            var theme = themeName == Properties.Resources.Theme_Dark ? ApplicationTheme.Dark : ApplicationTheme.Light;
-            ApplicationThemeManager.Apply(theme);
+            if (themeName == Properties.Resources.Theme_System)
+            {
+                // 跟随系统主题
+                _isFollowingSystem = true;
+
+                var sysTheme = SystemThemeManager.GetCachedSystemTheme() == SystemTheme.Dark
+                    ? ApplicationTheme.Dark
+                    : ApplicationTheme.Light;
+                ApplicationThemeManager.Apply(sysTheme);
+
+                if (window != null)
+                    SystemThemeWatcher.Watch(window);
+
+                if (saveTheme)
+                    SaveThemeCode("system");
+            }
+            else
+            {
+                // 手动选择 Light/Dark
+                _isFollowingSystem = false;
+
+                if (window != null)
+                    SystemThemeWatcher.UnWatch(window);
+
+                var theme = themeName == Properties.Resources.Theme_Dark
+                    ? ApplicationTheme.Dark
+                    : ApplicationTheme.Light;
+                ApplicationThemeManager.Apply(theme);
+
+                if (saveTheme)
+                    SaveThemeCode(themeName == Properties.Resources.Theme_Dark ? "dark" : "light");
+            }
         }
     }
 }

--- a/src/ViewModels/SettingsPageViewModel.cs
+++ b/src/ViewModels/SettingsPageViewModel.cs
@@ -88,7 +88,12 @@ namespace ExHyperV.ViewModels
 
         public SettingsPageViewModel()
         {
-            AvailableThemes = new List<string> { Properties.Resources.Theme_Light, Properties.Resources.Theme_Dark };
+            AvailableThemes = new List<string>
+            {
+                Properties.Resources.Theme_System,
+                Properties.Resources.Theme_Light,
+                Properties.Resources.Theme_Dark
+            };
             AvailableLanguages = new List<string> { Properties.Resources.Lang_Chinese, "English" };
 
             LoadCurrentSettings();
@@ -110,7 +115,8 @@ namespace ExHyperV.ViewModels
         partial void OnSelectedThemeChanged(string value)
         {
             if (_isInitializing || value == null) return;
-            SettingsService.ApplyTheme(value);
+            var mainWindow = System.Windows.Application.Current?.MainWindow;
+            SettingsService.ApplyTheme(value, mainWindow);
         }
 
         partial void OnSelectedLanguageChanged(string value)

--- a/src/Views/Windows/MainWindow.xaml.cs
+++ b/src/Views/Windows/MainWindow.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows;
+using ExHyperV.Services;
 using ExHyperV.Views;
-using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 
 namespace ExHyperV.Views
@@ -12,12 +12,9 @@ namespace ExHyperV.Views
             InitializeComponent();
             Loaded += PagePreload;
 
-            if (SystemThemeManager.GetCachedSystemTheme() == SystemTheme.Dark)
-            { //根据系统主题自动切换
-                ApplicationThemeManager.Apply(ApplicationTheme.Dark);
-            }
-            else { ApplicationThemeManager.Apply(ApplicationTheme.Light); }
-
+            //根据保存的设置初始化主题
+            SettingsService.ApplySavedTheme(this);
+            
         }
 
         private void PagePreload(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## 变更内容

本 PR 为应用主题设置新增“跟随系统”模式，并支持保存用户选择的主题偏好。

主要变更：

- 设置页主题选项新增“跟随系统”
- 新增主题配置读取与保存逻辑，支持 `system` / `light` / `dark`
- 应用启动时根据已保存的主题设置初始化主题
- 跟随系统模式下启用系统主题监听，系统主题变化时自动切换
- 手动选择浅色/深色时取消系统主题监听

## 关联 Issue
Closes #232 